### PR TITLE
Fixes for linux and mesa

### DIFF
--- a/glew_wish.py
+++ b/glew_wish.py
@@ -113,15 +113,15 @@ def glewInit(unsafe=False):
 	global GLEW_OGL_INFO
 
 	GLEW_OGL_INFO = collections.defaultdict(list)
-	for name in (GL_VENDOR,GL_RENDERER,GL_VERSION,GL_SHADING_LANGUAGE_VERSION,GL_EXTENSIONS):
-		GLEW_OGL_INFO[name] = glGetString(name).decode().split(' ')
+	for name in (GL_VENDOR,GL_RENDERER,GL_VERSION,GL_SHADING_LANGUAGE_VERSION):
+			GLEW_OGL_INFO[name] = glGetString(name).decode().split(' ')
 		
 	#It might be necessariy to use glGetStringi for extensions, so far glGetString has worked
 	#GLEW_OGL_INFO[GL_EXTENSIONS] = glGetStringi(GL_EXTENSIONS,<index>)
 	
 	# unique-ify extensions in set making the 'in' operator
 	# O(1) average case.
-	GLEW_OGL_INFO[GL_EXTENSIONS] = set(GLEW_OGL_INFO[GL_EXTENSIONS])
+	#GLEW_OGL_INFO[GL_EXTENSIONS] = set(GLEW_OGL_INFO[GL_EXTENSIONS])
 
 	# opengl versions as of 2014
 	ogl_version_history = {

--- a/objloader.py
+++ b/objloader.py
@@ -290,7 +290,7 @@ def main():
     # #obj_parse_assignment["#"](c)
     # print(c)
 
-    v,f,uv,n,c = load(".\\content\\suzanne.obj");
+    v,f,uv,n,c = load("Content/suzanne.obj")
     v,uv,n = process_obj(v,f,uv,n,c)
     print(v[0])
     print(uv[0])

--- a/tutorial1.py
+++ b/tutorial1.py
@@ -21,15 +21,15 @@ def main():
 	if not glfw.init():
 		return
 
-	# Open Window and create its OpenGL context
-	window = glfw.create_window(1024, 768, "Tutorial 01", None, None)
-
 	# 
 	glfw.window_hint(glfw.SAMPLES, 4)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
 	glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
 	glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+	# Open Window and create its OpenGL context
+	window = glfw.create_window(1024, 768, "Tutorial 01", None, None)
  
 	if not window:
 		print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)

--- a/tutorial10.py
+++ b/tutorial10.py
@@ -35,13 +35,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 10", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 10", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -104,8 +105,8 @@ def main():
     glBindVertexArray( vertex_array_id )
 
     # Create and compile our GLSL program from the shaders
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial10\\StandardShading.vertexshader",
-        ".\\shaders\\Tutorial10\\StandardTransparentShading.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial10/StandardShading.vertexshader",
+        "Shaders/Tutorial10/StandardTransparentShading.fragmentshader" )
 
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP")
@@ -113,13 +114,13 @@ def main():
     model_matrix_id = glGetUniformLocation(program_id, "M")
 
     # Load the texture
-    texture = textureutils.load_image(".\\content\\uvmap_suzanne.bmp")
+    texture = textureutils.load_image("Content/uvmap_suzanne.bmp")
 
     # Get a handle for our "myTextureSampler" uniform
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Read our OBJ file
-    vertices,faces,uvs,normals,colors = objloader.load(".\\content\\suzanne.obj")
+    vertices,faces,uvs,normals,colors = objloader.load("Content/suzanne.obj")
     vertex_data,uv_data,normal_data = objloader.process_obj( vertices,faces,uvs,normals,colors)
 
     # Our OBJ loader uses Python lists, convert to ctype arrays before sending to OpenGL

--- a/tutorial2.py
+++ b/tutorial2.py
@@ -29,13 +29,14 @@ def opengl_init():
 		print("Failed to initialize GLFW\n",file=sys.stderr)
 		return False
 
-	# Open Window and create its OpenGL context
-	window = glfw.create_window(1024, 768, "Tutorial 02", None, None) #(in the accompanying source code this variable will be global)
 	glfw.window_hint(glfw.SAMPLES, 4)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
 	glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
 	glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+	# Open Window and create its OpenGL context
+	window = glfw.create_window(1024, 768, "Tutorial 02", None, None) #(in the accompanying source code this variable will be global)
 
 	if not window:
 		print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -66,8 +67,8 @@ def main():
 	vertex_array_id = glGenVertexArrays(1)
 	glBindVertexArray( vertex_array_id )
 
-	program_id = common.LoadShaders( ".\\shaders\\Tutorial2\\SimpleVertexShader.vertexshader",
-		".\\shaders\\Tutorial2\\SimpleFragmentShader.fragmentshader" )
+	program_id = common.LoadShaders( "Shaders/Tutorial2/SimpleVertexShader.vertexshader",
+		"Shaders/Tutorial2/SimpleFragmentShader.fragmentshader" )
 	
 	vertex_data = [-1.0, -1.0, 0.0,
 					1.0, -1.0, 0.0,

--- a/tutorial3.py
+++ b/tutorial3.py
@@ -34,13 +34,14 @@ def opengl_init():
 		print("Failed to initialize GLFW\n",file=sys.stderr)
 		return False
 
-	# Open Window and create its OpenGL context
-	window = glfw.create_window(1024, 768, "Tutorial 03", None, None) #(in the accompanying source code this variable will be global)
 	glfw.window_hint(glfw.SAMPLES, 4)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
 	glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
 	glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+	# Open Window and create its OpenGL context
+	window = glfw.create_window(1024, 768, "Tutorial 03", None, None) #(in the accompanying source code this variable will be global)
 
 	if not window:
 		print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -71,8 +72,8 @@ def main():
 	vertex_array_id = glGenVertexArrays(1)
 	glBindVertexArray( vertex_array_id )
 
-	program_id = common.LoadShaders( ".\\shaders\\Tutorial3\\SimpleTransform.vertexshader", 
-		".\\shaders\\Tutorial3\\SingleColor.fragmentshader" )
+	program_id = common.LoadShaders( "Shaders/Tutorial3/SimpleTransform.vertexshader", 
+		"Shaders/Tutorial3/SingleColor.fragmentshader" )
 	
 	# Get a handle for our "MVP" uniform
 	matrix_id= glGetUniformLocation(program_id, "MVP");

--- a/tutorial4.py
+++ b/tutorial4.py
@@ -31,13 +31,14 @@ def opengl_init():
 		print("Failed to initialize GLFW\n",file=sys.stderr)
 		return False
 
-	# Open Window and create its OpenGL context
-	window = glfw.create_window(1024, 768, "Tutorial 04", None, None) #(in the accompanying source code this variable will be global)
 	glfw.window_hint(glfw.SAMPLES, 4)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
 	glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
 	glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+	# Open Window and create its OpenGL context
+	window = glfw.create_window(1024, 768, "Tutorial 04", None, None) #(in the accompanying source code this variable will be global)
 
 	if not window:
 		print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -84,8 +85,8 @@ def main():
 	vertex_array_id = glGenVertexArrays(1)
 	glBindVertexArray( vertex_array_id )
 
-	program_id = common.LoadShaders( ".\\shaders\\Tutorial4\\TransformVertexShader.vertexshader",
-		".\\shaders\\Tutorial4\\ColorFragmentShader.fragmentshader" )
+	program_id = common.LoadShaders( "Shaders/Tutorial4/TransformVertexShader.vertexshader",
+		"Shaders/Tutorial4/ColorFragmentShader.fragmentshader" )
 	
 	# Get a handle for our "MVP" uniform
 	matrix_id= glGetUniformLocation(program_id, "MVP");
@@ -196,6 +197,11 @@ def main():
 
 
 	while glfw.get_key(window,glfw.KEY_ESCAPE) != glfw.PRESS and not glfw.window_should_close(window):
+		# Enable depth test
+		glEnable(GL_DEPTH_TEST)
+		# Accept fragment if it closer to the camera than the former one
+		glDepthFunc(GL_LESS)
+        
 		glClear(GL_COLOR_BUFFER_BIT| GL_DEPTH_BUFFER_BIT)
 
 		glUseProgram(program_id)

--- a/tutorial6.py
+++ b/tutorial6.py
@@ -32,13 +32,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 06", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 06", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -137,13 +138,13 @@ def main():
     vertex_array_id = glGenVertexArrays(1)
     glBindVertexArray( vertex_array_id )
 
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial6\\TransformVertexShader.vertexshader",
-        ".\\shaders\\Tutorial6\\TextureFragmentShader.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial6/TransformVertexShader.vertexshader",
+        "Shaders/Tutorial6/TextureFragmentShader.fragmentshader" )
     
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP");
 
-    texture = load_image(".\\content\\uvtemplate.bmp")
+    texture = load_image("Content/uvtemplate.bmp")
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Our vertices. Tree consecutive floats give a 3D vertex; Three consecutive vertices give a triangle.

--- a/tutorial7.py
+++ b/tutorial7.py
@@ -33,13 +33,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 07", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 07", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -144,20 +145,20 @@ def main():
     glBindVertexArray( vertex_array_id )
 
     # Create and compile our GLSL program from the shaders
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial7\\TransformVertexShader.vertexshader",
-        ".\\shaders\\Tutorial7\\TextureFragmentShader.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial7/TransformVertexShader.vertexshader",
+        "Shaders/Tutorial7/TextureFragmentShader.fragmentshader" )
     
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP")
 
     # Load the texture
-    texture = load_image(".\\content\\uvmap.bmp")
+    texture = load_image("Content/uvmap.bmp")
 
     # Get a handle for our "myTextureSampler" uniform
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Read our OBJ file
-    vertices,faces,uvs,normals,colors = objloader.load(".\\content\\cube.obj")
+    vertices,faces,uvs,normals,colors = objloader.load("Content/cube.obj")
     vertex_data,uv_data,normal_data = objloader.process_obj( vertices,faces,uvs,normals,colors)
 
     # Our OBJ loader uses Python lists, convert to ctype arrays before sending to OpenGL

--- a/tutorial8.py
+++ b/tutorial8.py
@@ -33,13 +33,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 08", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 08", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -144,8 +145,8 @@ def main():
     glBindVertexArray( vertex_array_id )
 
     # Create and compile our GLSL program from the shaders
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial8\\StandardShading.vertexshader",
-        ".\\shaders\\Tutorial8\\StandardShading.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial8/StandardShading.vertexshader",
+        "Shaders/Tutorial8/StandardShading.fragmentshader" )
     
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP")
@@ -153,13 +154,13 @@ def main():
     model_matrix_id = glGetUniformLocation(program_id, "M")
 
     # Load the texture
-    texture = load_image(".\\content\\uvmap_suzanne.bmp")
+    texture = load_image("Content/uvmap_suzanne.bmp")
 
     # Get a handle for our "myTextureSampler" uniform
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Read our OBJ file
-    vertices,faces,uvs,normals,colors = objloader.load(".\\content\\suzanne.obj")
+    vertices,faces,uvs,normals,colors = objloader.load("Content/suzanne.obj")
     vertex_data,uv_data,normal_data = objloader.process_obj( vertices,faces,uvs,normals,colors)
 
     # Our OBJ loader uses Python lists, convert to ctype arrays before sending to OpenGL

--- a/tutorial9.py
+++ b/tutorial9.py
@@ -35,13 +35,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 09", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 09", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -104,8 +105,8 @@ def main():
     glBindVertexArray( vertex_array_id )
 
     # Create and compile our GLSL program from the shaders
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial9\\StandardShading.vertexshader",
-        ".\\shaders\\Tutorial9\\StandardShading.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial9/StandardShading.vertexshader",
+        "Shaders/Tutorial9/StandardShading.fragmentshader" )
     
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP")
@@ -113,13 +114,13 @@ def main():
     model_matrix_id = glGetUniformLocation(program_id, "M")
 
     # Load the texture
-    texture = textureutils.load_image(".\\content\\uvmap_suzanne.bmp")
+    texture = textureutils.load_image("Content/uvmap_suzanne.bmp")
 
     # Get a handle for our "myTextureSampler" uniform
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Read our OBJ file
-    vertices,faces,uvs,normals,colors = objloader.load(".\\content\\suzanne.obj")
+    vertices,faces,uvs,normals,colors = objloader.load("Content/suzanne.obj")
     vertex_data,uv_data,normal_data = objloader.process_obj( vertices,faces,uvs,normals,colors)
 
     # Our OBJ loader uses Python lists, convert to ctype arrays before sending to OpenGL


### PR DESCRIPTION
Hi,
   I've been getting these working on mesa on Linux - these drivers are a lot stricter than the commercial ones so some things don't work right away.

Main stuff:
- Use forwardslashes for paths (python should be fine with this in Windows).
- glfw window hints for 3.3 context have to come _before_ window creation
- glew_wish -glGetStringi for extensions killed stuff, so I've temporarily commented it out.

I've got up to tutorial5, but it's not included as I spent about a day trying to understand why textures were just black before rewriting the texture part, so that's something you might not want to 'just merge'.

S
