### PR TITLE
Rewrite of Tutorial5 texture loading code

### DIFF
--- a/glew_wish.py
+++ b/glew_wish.py
@@ -113,15 +113,15 @@ def glewInit(unsafe=False):
 	global GLEW_OGL_INFO
 
 	GLEW_OGL_INFO = collections.defaultdict(list)
-	for name in (GL_VENDOR,GL_RENDERER,GL_VERSION,GL_SHADING_LANGUAGE_VERSION,GL_EXTENSIONS):
-		GLEW_OGL_INFO[name] = glGetString(name).decode().split(' ')
+	for name in (GL_VENDOR,GL_RENDERER,GL_VERSION,GL_SHADING_LANGUAGE_VERSION):
+			GLEW_OGL_INFO[name] = glGetString(name).decode().split(' ')
 		
 	#It might be necessariy to use glGetStringi for extensions, so far glGetString has worked
 	#GLEW_OGL_INFO[GL_EXTENSIONS] = glGetStringi(GL_EXTENSIONS,<index>)
 	
 	# unique-ify extensions in set making the 'in' operator
 	# O(1) average case.
-	GLEW_OGL_INFO[GL_EXTENSIONS] = set(GLEW_OGL_INFO[GL_EXTENSIONS])
+	#GLEW_OGL_INFO[GL_EXTENSIONS] = set(GLEW_OGL_INFO[GL_EXTENSIONS])
 
 	# opengl versions as of 2014
 	ogl_version_history = {

--- a/objloader.py
+++ b/objloader.py
@@ -290,7 +290,7 @@ def main():
     # #obj_parse_assignment["#"](c)
     # print(c)
 
-    v,f,uv,n,c = load(".\\content\\suzanne.obj");
+    v,f,uv,n,c = load("Content/suzanne.obj")
     v,uv,n = process_obj(v,f,uv,n,c)
     print(v[0])
     print(uv[0])

--- a/tutorial1.py
+++ b/tutorial1.py
@@ -21,15 +21,15 @@ def main():
 	if not glfw.init():
 		return
 
-	# Open Window and create its OpenGL context
-	window = glfw.create_window(1024, 768, "Tutorial 01", None, None)
-
 	# 
 	glfw.window_hint(glfw.SAMPLES, 4)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
 	glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
 	glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+	# Open Window and create its OpenGL context
+	window = glfw.create_window(1024, 768, "Tutorial 01", None, None)
  
 	if not window:
 		print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)

--- a/tutorial10.py
+++ b/tutorial10.py
@@ -35,13 +35,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 10", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 10", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -104,8 +105,8 @@ def main():
     glBindVertexArray( vertex_array_id )
 
     # Create and compile our GLSL program from the shaders
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial10\\StandardShading.vertexshader",
-        ".\\shaders\\Tutorial10\\StandardTransparentShading.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial10/StandardShading.vertexshader",
+        "Shaders/Tutorial10/StandardTransparentShading.fragmentshader" )
 
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP")
@@ -113,13 +114,13 @@ def main():
     model_matrix_id = glGetUniformLocation(program_id, "M")
 
     # Load the texture
-    texture = textureutils.load_image(".\\content\\uvmap_suzanne.bmp")
+    texture = textureutils.load_image("Content/uvmap_suzanne.bmp")
 
     # Get a handle for our "myTextureSampler" uniform
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Read our OBJ file
-    vertices,faces,uvs,normals,colors = objloader.load(".\\content\\suzanne.obj")
+    vertices,faces,uvs,normals,colors = objloader.load("Content/suzanne.obj")
     vertex_data,uv_data,normal_data = objloader.process_obj( vertices,faces,uvs,normals,colors)
 
     # Our OBJ loader uses Python lists, convert to ctype arrays before sending to OpenGL

--- a/tutorial2.py
+++ b/tutorial2.py
@@ -29,13 +29,14 @@ def opengl_init():
 		print("Failed to initialize GLFW\n",file=sys.stderr)
 		return False
 
-	# Open Window and create its OpenGL context
-	window = glfw.create_window(1024, 768, "Tutorial 02", None, None) #(in the accompanying source code this variable will be global)
 	glfw.window_hint(glfw.SAMPLES, 4)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
 	glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
 	glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+	# Open Window and create its OpenGL context
+	window = glfw.create_window(1024, 768, "Tutorial 02", None, None) #(in the accompanying source code this variable will be global)
 
 	if not window:
 		print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -66,8 +67,8 @@ def main():
 	vertex_array_id = glGenVertexArrays(1)
 	glBindVertexArray( vertex_array_id )
 
-	program_id = common.LoadShaders( ".\\shaders\\Tutorial2\\SimpleVertexShader.vertexshader",
-		".\\shaders\\Tutorial2\\SimpleFragmentShader.fragmentshader" )
+	program_id = common.LoadShaders( "Shaders/Tutorial2/SimpleVertexShader.vertexshader",
+		"Shaders/Tutorial2/SimpleFragmentShader.fragmentshader" )
 	
 	vertex_data = [-1.0, -1.0, 0.0,
 					1.0, -1.0, 0.0,

--- a/tutorial3.py
+++ b/tutorial3.py
@@ -34,13 +34,14 @@ def opengl_init():
 		print("Failed to initialize GLFW\n",file=sys.stderr)
 		return False
 
-	# Open Window and create its OpenGL context
-	window = glfw.create_window(1024, 768, "Tutorial 03", None, None) #(in the accompanying source code this variable will be global)
 	glfw.window_hint(glfw.SAMPLES, 4)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
 	glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
 	glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+	# Open Window and create its OpenGL context
+	window = glfw.create_window(1024, 768, "Tutorial 03", None, None) #(in the accompanying source code this variable will be global)
 
 	if not window:
 		print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -71,8 +72,8 @@ def main():
 	vertex_array_id = glGenVertexArrays(1)
 	glBindVertexArray( vertex_array_id )
 
-	program_id = common.LoadShaders( ".\\shaders\\Tutorial3\\SimpleTransform.vertexshader", 
-		".\\shaders\\Tutorial3\\SingleColor.fragmentshader" )
+	program_id = common.LoadShaders( "Shaders/Tutorial3/SimpleTransform.vertexshader", 
+		"Shaders/Tutorial3/SingleColor.fragmentshader" )
 	
 	# Get a handle for our "MVP" uniform
 	matrix_id= glGetUniformLocation(program_id, "MVP");

--- a/tutorial4.py
+++ b/tutorial4.py
@@ -31,13 +31,14 @@ def opengl_init():
 		print("Failed to initialize GLFW\n",file=sys.stderr)
 		return False
 
-	# Open Window and create its OpenGL context
-	window = glfw.create_window(1024, 768, "Tutorial 04", None, None) #(in the accompanying source code this variable will be global)
 	glfw.window_hint(glfw.SAMPLES, 4)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
 	glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
 	glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
 	glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+	# Open Window and create its OpenGL context
+	window = glfw.create_window(1024, 768, "Tutorial 04", None, None) #(in the accompanying source code this variable will be global)
 
 	if not window:
 		print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -84,8 +85,8 @@ def main():
 	vertex_array_id = glGenVertexArrays(1)
 	glBindVertexArray( vertex_array_id )
 
-	program_id = common.LoadShaders( ".\\shaders\\Tutorial4\\TransformVertexShader.vertexshader",
-		".\\shaders\\Tutorial4\\ColorFragmentShader.fragmentshader" )
+	program_id = common.LoadShaders( "Shaders/Tutorial4/TransformVertexShader.vertexshader",
+		"Shaders/Tutorial4/ColorFragmentShader.fragmentshader" )
 	
 	# Get a handle for our "MVP" uniform
 	matrix_id= glGetUniformLocation(program_id, "MVP");
@@ -196,6 +197,11 @@ def main():
 
 
 	while glfw.get_key(window,glfw.KEY_ESCAPE) != glfw.PRESS and not glfw.window_should_close(window):
+		# Enable depth test
+		glEnable(GL_DEPTH_TEST)
+		# Accept fragment if it closer to the camera than the former one
+		glDepthFunc(GL_LESS)
+        
 		glClear(GL_COLOR_BUFFER_BIT| GL_DEPTH_BUFFER_BIT)
 
 		glUseProgram(program_id)

--- a/tutorial5.py
+++ b/tutorial5.py
@@ -12,8 +12,10 @@ from OpenGL.GLUT import *
 from OpenGL.GLUT.special import *
 from OpenGL.GL.shaders import *
 from glew_wish import *
+from PIL import Image
+import numpy
+
 from csgl import *
-from PIL.Image import open as pil_open
 
 import common
 import glfw
@@ -25,182 +27,150 @@ window = None
 null = c_void_p(0)
 
 def opengl_init():
-    global window
-    # Initialize the library
-    if not glfw.init():
-        print("Failed to initialize GLFW\n",file=sys.stderr)
-        return False
+	global window
+	# Initialize the library
+	if not glfw.init():
+		print("Failed to initialize GLFW\n",file=sys.stderr)
+		return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 05", None, None) #(in the accompanying source code this variable will be global)
-    glfw.window_hint(glfw.SAMPLES, 4)
-    glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
-    glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
-    glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
-    glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+	glfw.window_hint(glfw.SAMPLES, 4)
+	glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+	glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
+	glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
+	glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
 
-    if not window:
-        print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
-        glfw.terminate()
-        return False
+	# Open Window and create its OpenGL context
+	window = glfw.create_window(1024, 768, "Tutorial 05", None, None) #(in the accompanying source code this variable will be global)
 
-    # Initialize GLEW
-    glfw.make_context_current(window)
-    glewExperimental = True
+	if not window:
+		print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
+		glfw.terminate()
+		return False
 
-    # GLEW is a framework for testing extension availability.  Please see tutorial notes for
-    # more information including why can remove this code.
-    if glewInit() != GLEW_OK:
-        print("Failed to initialize GLEW\n",file=sys.stderr);
-        return False
-    return True
+	# Initialize GLEW
+	glfw.make_context_current(window)
+	glewExperimental = True
 
-def bind_texture(texture_id,mode):
-    """ Bind texture_id using several different modes
+	# GLEW is a framework for testing extension availability.  Please see tutorial notes for
+	# more information including why can remove this code.
+	if glewInit() != GLEW_OK:
+		print("Failed to initialize GLEW\n",file=sys.stderr);
+		return False
+	return True
 
-        Notes:
-            Without mipmapping the texture is incomplete
-            and requires additional constraints on OpenGL
-            to properly render said texture.
 
-            Use 'MIN_FILTER" or 'MAX_LEVEL' to render
-            a generic texture with a single resolution
-        Ref:
-            [] - http://www.opengl.org/wiki/Common_Mistakes#Creating_a_complete_texture
-            [] - http://gregs-blog.com/2008/01/17/opengl-texture-filter-parameters-explained/
-        TODO:
-            - Rename modes to something useful
-    """
-    if mode == 'DEFAULT':
-        glBindTexture(GL_TEXTURE_2D, texture_id)
-        glPixelStorei(GL_UNPACK_ALIGNMENT,1) 
-    elif mode == 'MIN_FILTER':
-        glBindTexture(GL_TEXTURE_2D, texture_id)
-        glPixelStorei(GL_UNPACK_ALIGNMENT,1) 
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
-    elif mode == 'MAX_LEVEL':
-        glBindTexture(GL_TEXTURE_2D, texture_id)
-        glPixelStorei(GL_UNPACK_ALIGNMENT,1) 
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0)
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0)
-    else:
-        glBindTexture(GL_TEXTURE_2D, texture_id)
-        glPixelStorei(GL_UNPACK_ALIGNMENT,1)
+def key_event(window,key,scancode,action,mods):
+	""" Handle keyboard events
 
-    # Generate mipmaps?  Doesn't seem to work
+		Note:  It's not important to understand how this works just yet.
+		Keyboard and mouse inputs are covered in Tutorial 6
+	"""
+	if action == glfw.PRESS and key == glfw.KEY_D:
+		if glIsEnabled (GL_DEPTH_TEST): glDisable(GL_DEPTH_TEST)
+		else: glEnable(GL_DEPTH_TEST)
+
+		glDepthFunc(GL_LESS)
+
+
+def load_texture(name):
+
+    img = Image.open(name) # .jpg, .bmp, etc. also work
+    img_data = numpy.array(list(img.getdata()), numpy.int8)
+
+    id = glGenTextures(1)
+    #glPixelStorei(GL_UNPACK_ALIGNMENT,1)
+    glBindTexture(GL_TEXTURE_2D, id)
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, img.size[0], img.size[1], 0, GL_RGB, GL_UNSIGNED_BYTE, img_data)
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR)
     glGenerateMipmap(GL_TEXTURE_2D)
-
-def load_image(file_name):
-    im = pil_open(file_name)
-    try:
-        width,height,image = im.size[0], im.size[1], im.tostring("raw", "RGBA", 0, -1)
-    except SystemError:
-        width,height,image = im.size[0], im.size[1], im.tostring("raw", "RGBX", 0, -1)
-
-    texture_id =  glGenTextures(1)
-
-    # To use OpenGL 4.2 ARB_texture_storage to automatically generate a single mipmap layer
-    # uncomment the 3 lines below.  Note that this should replaced glTexImage2D below.
-    #bind_texture(texture_id,'DEFAULT')
-    #glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, width, height);
-    #glTexSubImage2D(GL_TEXTURE_2D,0,0,0,width,height,GL_RGBA,GL_UNSIGNED_BYTE,image)
-    
-    # "Bind" the newly created texture : all future texture functions will modify this texture
-    bind_texture(texture_id,'MIN_FILTER')
-    glTexImage2D(
-           GL_TEXTURE_2D, 0, 3, width, height, 0,
-           GL_RGBA, GL_UNSIGNED_BYTE, image
-       )
-    return texture_id
+    return id
 
 def main():
-    if not opengl_init():
-        return
+	if not opengl_init():
+		return
 
-    # Enable key events
-    glfw.set_input_mode(window,glfw.STICKY_KEYS,GL_TRUE) 
-    
-    # Set opengl clear color to something other than red (color used by the fragment shader)
-    glClearColor(0.0,0.0,0.4,0.0)
-    
-    # Enable depth test
-    glEnable(GL_DEPTH_TEST);
-    # Accept fragment if it closer to the camera than the former one
-    glDepthFunc(GL_LESS); 
+	# Enable key events
+	glfw.set_input_mode(window,glfw.STICKY_KEYS,GL_TRUE) 
+	
+	# Enable key event callback
+	glfw.set_key_callback(window,key_event)
 
-    vertex_array_id = glGenVertexArrays(1)
-    glBindVertexArray( vertex_array_id )
+	# Set opengl clear color to something other than red (color used by the fragment shader)
+	glClearColor(0,0,0.4,0)
+	
+	vertex_array_id = glGenVertexArrays(1)
+	glBindVertexArray( vertex_array_id )
 
+	program_id = common.LoadShaders( "Shaders/Tutorial5/TransformVertexShader.vertexshader", "Shaders/Tutorial5/TextureFragmentShader.fragmentshader" )
+	
+	# Get a handle for our "MVP" uniform
+	matrix_id= glGetUniformLocation(program_id, "MVP");
 
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial5\\TransformVertexShader.vertexshader",
-        ".\\shaders\\Tutorial5\\TextureFragmentShader.fragmentshader" )
-    
-    # Get a handle for our "MVP" uniform
-    matrix_id = glGetUniformLocation(program_id, "MVP");
+	# Projection matrix : 45 Field of View, 4:3 ratio, display range : 0.1 unit <-> 100 units
+	projection = mat4.perspective(45.0, 4.0 / 3.0, 0.1, 100.0)
+	
+	# Camera matrix
+	view = mat4.lookat(vec3(4,3,-3), # Camera is at (4,3,3), in World Space
+					vec3(0,0,0), # and looks at the origin
+					vec3(0,1,0)) 
+	
+	# Model matrix : an identity matrix (model will be at the origin)
+	model = mat4.identity()
 
-    # Projection matrix : 45 Field of View, 4:3 ratio, display range : 0.1 unit <-> 100 units
-    projection = mat4.perspective(45.0, 4.0 / 3.0, 0.1, 100.0)
-    
-    # Camera matrix
-    view = mat4.lookat(vec3(4,3,-3), # Camera is at (4,3,3), in World Space
-                    vec3(0,0,0), # and looks at the origin
-                    vec3(0,1,0)) 
-    
-    # Model matrix : an identity matrix (model will be at the origin)
-    model = mat4.identity()
+	# Our ModelViewProjection : multiplication of our 3 matrices
+	mvp = projection * view * model
 
-    # Our ModelViewProjection : multiplication of our 3 matrices
-    mvp = projection * view * model
+	texture = load_texture("Content/uvtemplate.bmp")
 
+	texture_id = glGetUniformLocation(program_id, "myTextureSampler")
 
-    texture = load_image(".\\content\\uvtemplate.bmp")
-    texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
-
-    # Our vertices. Tree consecutive floats give a 3D vertex; Three consecutive vertices give a triangle.
-    # A cube has 6 faces with 2 triangles each, so this makes 6*2=12 triangles, and 12*3 vertices
-    vertex_data = [ 
-        -1.0,-1.0,-1.0,
-        -1.0,-1.0, 1.0,
-        -1.0, 1.0, 1.0,
-         1.0, 1.0,-1.0,
-        -1.0,-1.0,-1.0,
-        -1.0, 1.0,-1.0,
-         1.0,-1.0, 1.0,
-        -1.0,-1.0,-1.0,
-         1.0,-1.0,-1.0,
-         1.0, 1.0,-1.0,
-         1.0,-1.0,-1.0,
-        -1.0,-1.0,-1.0,
-        -1.0,-1.0,-1.0,
-        -1.0, 1.0, 1.0,
-        -1.0, 1.0,-1.0,
-         1.0,-1.0, 1.0,
-        -1.0,-1.0, 1.0,
-        -1.0,-1.0,-1.0,
-        -1.0, 1.0, 1.0,
-        -1.0,-1.0, 1.0,
-         1.0,-1.0, 1.0,
-         1.0, 1.0, 1.0,
-         1.0,-1.0,-1.0,
-         1.0, 1.0,-1.0,
-         1.0,-1.0,-1.0,
-         1.0, 1.0, 1.0,
-         1.0,-1.0, 1.0,
-         1.0, 1.0, 1.0,
-         1.0, 1.0,-1.0,
-        -1.0, 1.0,-1.0,
-         1.0, 1.0, 1.0,
-        -1.0, 1.0,-1.0,
-        -1.0, 1.0, 1.0,
-         1.0, 1.0, 1.0,
-        -1.0, 1.0, 1.0,
-         1.0,-1.0, 1.0]
+	# Our vertices. Tree consecutive floats give a 3D vertex; Three consecutive vertices give a triangle.
+	# A cube has 6 faces with 2 triangles each, so this makes 6*2=12 triangles, and 12*3 vertices
+	vertex_data = [ 
+		-1.0,-1.0,-1.0,
+		-1.0,-1.0, 1.0,
+		-1.0, 1.0, 1.0,
+		 1.0, 1.0,-1.0,
+		-1.0,-1.0,-1.0,
+		-1.0, 1.0,-1.0,
+		 1.0,-1.0, 1.0,
+		-1.0,-1.0,-1.0,
+		 1.0,-1.0,-1.0,
+		 1.0, 1.0,-1.0,
+		 1.0,-1.0,-1.0,
+		-1.0,-1.0,-1.0,
+		-1.0,-1.0,-1.0,
+		-1.0, 1.0, 1.0,
+		-1.0, 1.0,-1.0,
+		 1.0,-1.0, 1.0,
+		-1.0,-1.0, 1.0,
+		-1.0,-1.0,-1.0,
+		-1.0, 1.0, 1.0,
+		-1.0,-1.0, 1.0,
+		 1.0,-1.0, 1.0,
+		 1.0, 1.0, 1.0,
+		 1.0,-1.0,-1.0,
+		 1.0, 1.0,-1.0,
+		 1.0,-1.0,-1.0,
+		 1.0, 1.0, 1.0,
+		 1.0,-1.0, 1.0,
+		 1.0, 1.0, 1.0,
+		 1.0, 1.0,-1.0,
+		-1.0, 1.0,-1.0,
+		 1.0, 1.0, 1.0,
+		-1.0, 1.0,-1.0,
+		-1.0, 1.0, 1.0,
+		 1.0, 1.0, 1.0,
+		-1.0, 1.0, 1.0,
+		 1.0,-1.0, 1.0]
 
     # Two UV coordinatesfor each vertex. They were created withe Blender.
-    uv_data = [ 
+	uv_data = [ 
         0.000059, 1.0-0.000004, 
         0.000103, 1.0-0.336048, 
         0.335973, 1.0-0.335903, 
@@ -238,80 +208,86 @@ def main():
         1.000004, 1.0-0.671847, 
         0.667979, 1.0-0.335851]
 
-    vertex_buffer = glGenBuffers(1);
-    array_type = GLfloat * len(vertex_data)
-    glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer)
-    glBufferData(GL_ARRAY_BUFFER, len(vertex_data) * 4, array_type(*vertex_data), GL_STATIC_DRAW)
+	vertex_buffer = glGenBuffers(1);
+	array_type = GLfloat * len(vertex_data)
+	glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer)
+	glBufferData(GL_ARRAY_BUFFER, len(vertex_data) * 4, array_type(*vertex_data), GL_STATIC_DRAW)
 
-    uv_buffer = glGenBuffers(1);
-    array_type = GLfloat * len(uv_data)
-    glBindBuffer(GL_ARRAY_BUFFER, uv_buffer)
-    glBufferData(GL_ARRAY_BUFFER, len(uv_data) * 4, array_type(*uv_data), GL_STATIC_DRAW)
+	uv_buffer = glGenBuffers(1);
+	array_type = GLfloat * len(uv_data)
+	glBindBuffer(GL_ARRAY_BUFFER, uv_buffer)
+	glBufferData(GL_ARRAY_BUFFER, len(uv_data) * 4, array_type(*uv_data), GL_STATIC_DRAW)
 
 
 
-    while glfw.get_key(window,glfw.KEY_ESCAPE) != glfw.PRESS and not glfw.window_should_close(window):
-        glClear(GL_COLOR_BUFFER_BIT| GL_DEPTH_BUFFER_BIT)
-
-        glUseProgram(program_id)
-
-        # Send our transformation to the currently bound shader, 
-        # in the "MVP" uniform
-        glUniformMatrix4fv(matrix_id, 1, GL_FALSE,mvp.data)
+	while glfw.get_key(window,glfw.KEY_ESCAPE) != glfw.PRESS and not glfw.window_should_close(window):
+		# Enable depth test
+		glEnable(GL_DEPTH_TEST)
+		# Accept fragment if it closer to the camera than the former one
+		glDepthFunc(GL_LESS)
         
-        # Bind our texture in Texture Unit 0
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, texture);
-        # Set our "myTextureSampler" sampler to user Texture Unit 0
-        glUniform1i(texture_id, 0);
+		glClear(GL_COLOR_BUFFER_BIT| GL_DEPTH_BUFFER_BIT)
 
-        #1rst attribute buffer : vertices
-        glEnableVertexAttribArray(0)
-        glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer);
-        glVertexAttribPointer(
-            0,                  # attribute 0. No particular reason for 0, but must match the layout in the shader.
-            3,                  # len(vertex_data)
-            GL_FLOAT,           # type
-            GL_FALSE,           # ormalized?
-            0,                  # stride
-            null                # array buffer offset (c_type == void*)
-            )
+		glUseProgram(program_id)
 
-        # 2nd attribute buffer : colors
-        glEnableVertexAttribArray(1)
-        glBindBuffer(GL_ARRAY_BUFFER, uv_buffer);
-        glVertexAttribPointer(
-            1,                  # attribute 0. No particular reason for 0, but must match the layout in the shader.
-            2,                  # len(vertex_data)
-            GL_FLOAT,           # type
-            GL_FALSE,           # ormalized?
-            0,                  # stride
-            null                # array buffer offset (c_type == void*)
-            )
+		# Send our transformation to the currently bound shader, 
+		# in the "MVP" uniform
+		glUniformMatrix4fv(matrix_id, 1, GL_FALSE,mvp.data)
 
-        # Draw the triangle !
-        glDrawArrays(GL_TRIANGLES, 0, 12*3) #3 indices starting at 0 -> 1 triangle
+        # Bind our trxture in Texture Unit 0
+		glActiveTexture(GL_TEXTURE0)
+		glBindTexture(GL_TEXTURE_2D, texture)
+		glUniform1i(texture_id, 0)
 
-        # Not strictly necessary because we only have 
-        glDisableVertexAttribArray(0)
-        glDisableVertexAttribArray(1)
-    
-    
-        # Swap front and back buffers
-        glfw.swap_buffers(window)
+		# Enable the vertex attribute at element[0], in this case that's the triangle's vertices
+		# this could also be color, normals, etc.  It isn't necessary to disable these
+		#
+		#1rst attribute buffer : vertices
+		glEnableVertexAttribArray(0)
+		glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer);
+		glVertexAttribPointer(
+			0,                  # attribute 0. No particular reason for 0, but must match the layout in the shader.
+			3,                  # len(vertex_data)
+			GL_FLOAT,           # type
+			GL_FALSE,           # ormalized?
+			0,                  # stride
+			null           		# array buffer offset (c_type == void*)
+			)
 
-        # Poll for and process events
-        glfw.poll_events()
+		# 2nd attribute buffer : UVs
+		glEnableVertexAttribArray(1)
+		glBindBuffer(GL_ARRAY_BUFFER, uv_buffer);
+		glVertexAttribPointer(
+			1,                  # attribute 0. No particular reason for 0, but must match the layout in the shader.
+			2,                  # len(vertex_data)
+			GL_FLOAT,           # type
+			GL_FALSE,           # normalized?
+			0,                  # stride
+			null           		# array buffer offset (c_type == void*)
+			)
 
-    # note braces around vertex_buffer and vertex_array_id.  
-    # These 2 functions expect arrays of values
-    glDeleteBuffers(1, [vertex_buffer])
-    glDeleteBuffers(1, [uv_buffer])
-    glDeleteProgram(program_id)
-    glDeleteTextures([texture_id])
-    glDeleteVertexArrays(1, [vertex_array_id])
+		# Draw the triangle !
+		glDrawArrays(GL_TRIANGLES, 0, 12*3) #3 indices starting at 0 -> 1 triangle
 
-    glfw.terminate()
+		# Not strictly necessary because we only have 
+		glDisableVertexAttribArray(0)
+		glDisableVertexAttribArray(1)
+	
+	
+		# Swap front and back buffers
+		glfw.swap_buffers(window)
+
+		# Poll for and process events
+		glfw.poll_events()
+
+	# note braces around vertex_buffer and vertex_array_id.  
+	# These 2 functions expect arrays of values
+	glDeleteBuffers(1, [vertex_buffer])
+	glDeleteBuffers(1, [uv_buffer])
+	glDeleteProgram(program_id)
+	glDeleteVertexArrays(1, [vertex_array_id])
+
+	glfw.terminate()
 
 if __name__ == "__main__":
-    main()
+	main()

--- a/tutorial6.py
+++ b/tutorial6.py
@@ -32,13 +32,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 06", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 06", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -137,13 +138,13 @@ def main():
     vertex_array_id = glGenVertexArrays(1)
     glBindVertexArray( vertex_array_id )
 
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial6\\TransformVertexShader.vertexshader",
-        ".\\shaders\\Tutorial6\\TextureFragmentShader.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial6/TransformVertexShader.vertexshader",
+        "Shaders/Tutorial6/TextureFragmentShader.fragmentshader" )
     
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP");
 
-    texture = load_image(".\\content\\uvtemplate.bmp")
+    texture = load_image("Content/uvtemplate.bmp")
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Our vertices. Tree consecutive floats give a 3D vertex; Three consecutive vertices give a triangle.

--- a/tutorial7.py
+++ b/tutorial7.py
@@ -33,13 +33,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 07", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 07", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -144,20 +145,20 @@ def main():
     glBindVertexArray( vertex_array_id )
 
     # Create and compile our GLSL program from the shaders
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial7\\TransformVertexShader.vertexshader",
-        ".\\shaders\\Tutorial7\\TextureFragmentShader.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial7/TransformVertexShader.vertexshader",
+        "Shaders/Tutorial7/TextureFragmentShader.fragmentshader" )
     
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP")
 
     # Load the texture
-    texture = load_image(".\\content\\uvmap.bmp")
+    texture = load_image("Content/uvmap.bmp")
 
     # Get a handle for our "myTextureSampler" uniform
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Read our OBJ file
-    vertices,faces,uvs,normals,colors = objloader.load(".\\content\\cube.obj")
+    vertices,faces,uvs,normals,colors = objloader.load("Content/cube.obj")
     vertex_data,uv_data,normal_data = objloader.process_obj( vertices,faces,uvs,normals,colors)
 
     # Our OBJ loader uses Python lists, convert to ctype arrays before sending to OpenGL

--- a/tutorial8.py
+++ b/tutorial8.py
@@ -33,13 +33,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 08", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 08", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -144,8 +145,8 @@ def main():
     glBindVertexArray( vertex_array_id )
 
     # Create and compile our GLSL program from the shaders
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial8\\StandardShading.vertexshader",
-        ".\\shaders\\Tutorial8\\StandardShading.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial8/StandardShading.vertexshader",
+        "Shaders/Tutorial8/StandardShading.fragmentshader" )
     
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP")
@@ -153,13 +154,13 @@ def main():
     model_matrix_id = glGetUniformLocation(program_id, "M")
 
     # Load the texture
-    texture = load_image(".\\content\\uvmap_suzanne.bmp")
+    texture = load_image("Content/uvmap_suzanne.bmp")
 
     # Get a handle for our "myTextureSampler" uniform
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Read our OBJ file
-    vertices,faces,uvs,normals,colors = objloader.load(".\\content\\suzanne.obj")
+    vertices,faces,uvs,normals,colors = objloader.load("Content/suzanne.obj")
     vertex_data,uv_data,normal_data = objloader.process_obj( vertices,faces,uvs,normals,colors)
 
     # Our OBJ loader uses Python lists, convert to ctype arrays before sending to OpenGL

--- a/tutorial9.py
+++ b/tutorial9.py
@@ -35,13 +35,14 @@ def opengl_init():
         print("Failed to initialize GLFW\n",file=sys.stderr)
         return False
 
-    # Open Window and create its OpenGL context
-    window = glfw.create_window(1024, 768, "Tutorial 09", None, None) #(in the accompanying source code this variable will be global)
     glfw.window_hint(glfw.SAMPLES, 4)
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
     glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL_TRUE)
     glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    # Open Window and create its OpenGL context
+    window = glfw.create_window(1024, 768, "Tutorial 09", None, None) #(in the accompanying source code this variable will be global)
 
     if not window:
         print("Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n",file=sys.stderr)
@@ -104,8 +105,8 @@ def main():
     glBindVertexArray( vertex_array_id )
 
     # Create and compile our GLSL program from the shaders
-    program_id = common.LoadShaders( ".\\shaders\\Tutorial9\\StandardShading.vertexshader",
-        ".\\shaders\\Tutorial9\\StandardShading.fragmentshader" )
+    program_id = common.LoadShaders( "Shaders/Tutorial9/StandardShading.vertexshader",
+        "Shaders/Tutorial9/StandardShading.fragmentshader" )
     
     # Get a handle for our "MVP" uniform
     matrix_id = glGetUniformLocation(program_id, "MVP")
@@ -113,13 +114,13 @@ def main():
     model_matrix_id = glGetUniformLocation(program_id, "M")
 
     # Load the texture
-    texture = textureutils.load_image(".\\content\\uvmap_suzanne.bmp")
+    texture = textureutils.load_image("Content/uvmap_suzanne.bmp")
 
     # Get a handle for our "myTextureSampler" uniform
     texture_id  = glGetUniformLocation(program_id, "myTextureSampler")
 
     # Read our OBJ file
-    vertices,faces,uvs,normals,colors = objloader.load(".\\content\\suzanne.obj")
+    vertices,faces,uvs,normals,colors = objloader.load("Content/suzanne.obj")
     vertex_data,uv_data,normal_data = objloader.process_obj( vertices,faces,uvs,normals,colors)
 
     # Our OBJ loader uses Python lists, convert to ctype arrays before sending to OpenGL


### PR DESCRIPTION
Also being new to opengl I had no idea how to fix the error I was getting under tutorial5.

I rewrote the texture loading code based on the original C++ (and some stackoverflow code on using PIL with textures).

The code in this pull request shows the textured cube in linux + mesa.

The error I was getting with the original code is this:

```
$ python tutorial5.py 
Compiling shader: Shaders/Tutorial5/TransformVertexShader.vertexshader
Compiling shader: Shaders/Tutorial5/TextureFragmentShader.fragmentshader
Linking program
Traceback (most recent call last):
  File "tutorial5.py", line 318, in <module>
    main()
  File "tutorial5.py", line 160, in main
    texture = load_image("Content/uvtemplate.bmp")
  File "tutorial5.py", line 113, in load_image
    bind_texture(texture_id,'MIN_FILTER')
  File "tutorial5.py", line 81, in bind_texture
    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP)
  File "/mnt/data/home/stu/.virtualenvs/3d/local/lib/python2.7/site-packages/OpenGL/platform/baseplatform.py", line 402, in __call__
    return self( *args, **named )
  File "/mnt/data/home/stu/.virtualenvs/3d/local/lib/python2.7/site-packages/OpenGL/error.py", line 232, in glCheckError
    baseOperation = baseOperation,
OpenGL.error.GLError: GLError(
    err = 1280,
    description = 'invalid enumerant',
    baseOperation = glTexParameterf,
    cArguments = (
        GL_TEXTURE_2D,
        GL_TEXTURE_WRAP_S,
        GL_CLAMP,
    )
)
```
